### PR TITLE
Compute length after UTF-8 encoding

### DIFF
--- a/libinjection/libinjection.pyx
+++ b/libinjection/libinjection.pyx
@@ -2,7 +2,8 @@ __author__ = 'wzhvictor@outlook.com'
 
 def is_sql_injection(payload):
     cdef c_sfilter *sfp = <c_sfilter *> malloc(sizeof(c_sfilter))
-    libinjection_sqli_init(sfp, payload.encode('utf_8'), len(payload), 0)
+    encoded_payload = payload.encode('utf_8')
+    libinjection_sqli_init(sfp, encoded_payload, len(encoded_payload), 0)
     res = dict(
         is_sqli=libinjection_is_sqli(sfp),
         fingerprint=sfp.fingerprint.decode('utf_8'),
@@ -12,8 +13,9 @@ def is_sql_injection(payload):
     return res
 
 def is_xss(payload):
+    encoded_payload = payload.encode('utf_8')
     for flag in range(5):
-        if libinjection_is_xss(payload.encode('utf_8'), len(payload), flag):
+        if libinjection_is_xss(encoded_payload, len(encoded_payload), flag):
             return dict(
                 is_xss=True,
                 flag=flag


### PR DESCRIPTION
Before this commit, buffer generated by `payload.encode('utf_8')` could
be freed before usage of this buffer in libinjection because no reference
to this buffer is stored. Also length of encoded payload may have been
greater then length of unencoded which might have lead to incomplete
payload processing.