### PR TITLE
Update setup.py, change install requirements to setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         include_dirs=['libinjection/src'],
         library_dirs=['libinjection/src'])
     ],
-    install_requires=[
+    setup_requires=[
         'setuptools>=38.3.0',
         'Cython>=0.23'
     ]


### PR DESCRIPTION
`setuptools` and `cython` are required for _setup_, not for _install_. Specifying them requirements in `setup_requires` will remove `setuptools` and `cython` as install dependencies, so they wont be required is this module is installed as a binary/wheel.