### PR TITLE
add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,4 @@ setup(
         include_dirs=['libinjection/src'],
         library_dirs=['libinjection/src'])
     ],
-    setup_requires=[
-        'setuptools>=38.3.0',
-        'Cython>=0.23'
-    ]
 )


### PR DESCRIPTION
Adding this file removes the need to have Cython already installed in the environment.

Doc from cython: https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules