### PR TITLE
Remove cython as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ libinjection/libinjection.c
 
 # Packages
 *.egg
+.eggs
 *.egg-info
 *.tar.gz
 dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]
+
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,4 @@ setup(
     packages=[],
     include_package_data=True,
     ext_modules=extensions,
-    install_requires=["setuptools>=38.3.0"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,44 +1,54 @@
 from setuptools import setup, Extension
-from Cython.Distutils import build_ext
 
-source_files = [
-    'libinjection/libinjection.pyx',
-    'libinjection/src/libinjection_sqli.c',
-    'libinjection/src/libinjection_html5.c',
-    'libinjection/src/libinjection_xss.c'
+USE_CYTHON = False
+
+try:
+    from Cython.Build import cythonize
+
+    USE_CYTHON = True
+except ImportError:
+    pass
+
+ext = ".pyx" if USE_CYTHON else ".c"
+
+extensions = [
+    Extension(
+        name="libinjection",
+        sources=[
+            "libinjection/libinjection" + ext,
+            "libinjection/src/libinjection_sqli.c",
+            "libinjection/src/libinjection_html5.c",
+            "libinjection/src/libinjection_xss.c",
+        ],
+        include_dirs=["libinjection/src"],
+        library_dirs=["libinjection/src"],
+    )
 ]
-cmd_class = {'build_ext': build_ext}
+
+if USE_CYTHON:
+    extensions = cythonize(extensions)
 
 setup(
-    name='libinjection-python',
-    version='1.1.4',
-    author='wzhvictor',
-    author_email='wzhvictor@outlook.com',
-    url='https://github.com/wzhvictor/libinjection-python',
-    description='Libinjection Python Wrapper',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
+    name="libinjection-python",
+    version="1.1.6",
+    author="wzhvictor",
+    author_email="wzhvictor@outlook.com",
+    url="https://github.com/wzhvictor/libinjection-python",
+    description="Libinjection Python Wrapper",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Natural Language :: English',
-        'Operating System :: Unix',
-        'Programming Language :: Cython',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Natural Language :: English",
+        "Operating System :: Unix",
+        "Programming Language :: Cython",
+        "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     packages=[],
     include_package_data=True,
-    cmdclass=cmd_class,
-    ext_modules=[Extension(
-        name='libinjection',
-        sources=source_files,
-        include_dirs=['libinjection/src'],
-        library_dirs=['libinjection/src'])
-    ],
-    setup_requires=[
-        'setuptools>=38.3.0',
-        'Cython>=0.23'
-    ]
+    ext_modules=extensions,
+    setup_requires=["setuptools>=38.3.0", "Cython>=0.23"],
 )

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
     packages=[],
     include_package_data=True,
     ext_modules=extensions,
-    setup_requires=["setuptools>=38.3.0", "Cython>=0.23"],
+    install_requires=["setuptools>=38.3.0"],
 )


### PR DESCRIPTION
The current `setup.py` imports from the `cython`, which means commands such as `python setup.py egg_info` will fail without Cython installed. Since the compiled Cython c module exists at `libinjection/libinjection.c` we can install this package without Cython at all.

- Adapt `setup.py` to allow installation with or without Cython
- Remove `setup_requires` kwarg and use `install_requires` kwarg instead, but don't list Cython as an install dependency to avoid unnecessary installation
- Add a `pyproject.toml` to allow pip to install Cython as a build dependency if necessary
